### PR TITLE
macos - update instruction for synthetic.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The tools were developed with Autodesk Flame 2025+, Python 3.11, & PySide 6.
 -------------------------------------------------------------------------------
 
     # Create /etc/synthetic.conf to link /PROJEKTS to test PROJEKTS directory:
-    sudo cat "PROJEKTS   Users/Shared/PROJEKTS" > /etc/synthetic.conf
+    echo "PROJEKTS	System/Volumes/Data/Users/Shared/PROJEKTS" | sudo tee /etc/synthetic.conf
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
updated the one-liner - though `tee` will overwrite synthetic.conf if it exists. nano or vi might be more appropriate....

and according to `man synthetic.conf`: All writeable paths must reside on the data volume, which is mounted at /System/Volumes/Data
ie:  
`PROJEKTS	System/Volumes/Data/Users/Shared/PROJEKTS`

This worked after reboot on 14.7 with SIP enabled, also when pointing to a LucidLink folder 